### PR TITLE
Added support for `clear` command on macOS (darwin)

### DIFF
--- a/aic_package/util.go
+++ b/aic_package/util.go
@@ -127,6 +127,7 @@ func init() {
 		cmd.Stdout = os.Stdout
 		cmd.Run()
 	}
+	clear["darwin"] = clear["linux"]
 }
 
 func clearScreen() {


### PR DESCRIPTION
This fixes the issue `"Error: your platform is unsupported, terminal can't be cleared"` when trying to convert a GIF in macOS.

[![asciicast](https://asciinema.org/a/MJWVbSGqFWQRF1j93pDUzA1bt.svg)](https://asciinema.org/a/MJWVbSGqFWQRF1j93pDUzA1bt)

