### PR TITLE
Used RGBA for color-bg flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,10 +404,10 @@ Saves the passed GIF as an ascii art GIF with the name `<image-name>-ascii-art.g
 
 > **Note:** This flag will be ignored if `--save-img` or `--save-gif` flags are not set
 
-This flag takes an RGB value that sets the background color in saved png and gif files.
+This flag takes an RGBA value that sets the background color in saved png and gif files.
 
 ```
-ascii-image-converter [image paths/urls] -s . --save-bg 255,255,255 # For white background
+ascii-image-converter [image paths/urls] -s . --save-bg 255,255,255,100 # For white background
 ```
 
 #### --font
@@ -481,7 +481,7 @@ func main() {
 	flags.SaveImagePath = "."
 	flags.CustomMap = " .-=+#@"
 	flags.FontFilePath = "./RobotoMono-Regular.ttf" // If file is in current directory
-	flags.SaveBackgroundColor = [3]int{50, 50, 50}
+	flags.SaveBackgroundColor = [4]int{50, 50, 50, 100}
 	
 	// Note: For environments where a terminal isn't available (such as web servers), you MUST
 	// specify atleast one of flags.Width, flags.Height or flags.Dimensions

--- a/aic_package/convert_root.go
+++ b/aic_package/convert_root.go
@@ -56,7 +56,7 @@ func DefaultFlags() Flags {
 		Full:                false,
 		FontFilePath:        "",
 		FontColor:           [3]int{255, 255, 255},
-		SaveBackgroundColor: [3]int{0, 0, 0},
+		SaveBackgroundColor: [4]int{0, 0, 0, 100},
 		Braille:             false,
 		Threshold:           128,
 		Dither:              false,

--- a/aic_package/create_ascii_image.go
+++ b/aic_package/create_ascii_image.go
@@ -74,10 +74,11 @@ func createImageToSave(asciiArt [][]imgManip.AsciiChar, colored bool, saveImageP
 	dc := gg.NewContext(imgWidth, imgHeight)
 
 	// Set image background
-	dc.SetRGB(
+	dc.SetRGBA(
 		float64(saveBgColor[0])/255,
 		float64(saveBgColor[1])/255,
 		float64(saveBgColor[2])/255,
+		float64(saveBgColor[3])/100,
 	)
 	dc.Clear()
 

--- a/aic_package/vars.go
+++ b/aic_package/vars.go
@@ -83,7 +83,7 @@ type Flags struct {
 
 	// Background RGB color in saved png or gif files.
 	// This will be ignored if Flags.SaveImagePath or Flags.SaveGifPath are not set
-	SaveBackgroundColor [3]int
+	SaveBackgroundColor [4]int
 
 	// Use braille characters instead of ascii. Terminal must support UTF-8 encoding.
 	// Otherwise, problems may be encountered with colored or even uncolored braille art.
@@ -122,7 +122,7 @@ var (
 	full          bool
 	fontPath      string
 	fontColor     [3]int
-	saveBgColor   [3]int
+	saveBgColor   [4]int
 	braille       bool
 	threshold     int
 	dither        bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ var (
 				Full:                full,
 				FontFilePath:        fontFile,
 				FontColor:           [3]int{fontColor[0], fontColor[1], fontColor[2]},
-				SaveBackgroundColor: [3]int{saveBgColor[0], saveBgColor[1], saveBgColor[2]},
+				SaveBackgroundColor: [4]int{saveBgColor[0], saveBgColor[1], saveBgColor[2],saveBgColor[3]},
 				Braille:             braille,
 				Threshold:           threshold,
 				Dither:              dither,
@@ -149,7 +149,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&saveImagePath, "save-img", "s", "", "Save ascii art as a .png file\nFormat: <image-name>-ascii-art.png\nImage will be saved in passed path\n(pass . for current directory)\n")
 	rootCmd.PersistentFlags().StringVar(&saveTxtPath, "save-txt", "", "Save ascii art as a .txt file\nFormat: <image-name>-ascii-art.txt\nFile will be saved in passed path\n(pass . for current directory)\n")
 	rootCmd.PersistentFlags().StringVar(&saveGifPath, "save-gif", "", "If input is a gif, save it as a .gif file\nFormat: <gif-name>-ascii-art.gif\nGif will be saved in passed path\n(pass . for current directory)\n")
-	rootCmd.PersistentFlags().IntSliceVar(&saveBgColor, "save-bg", nil, "Set background color for --save-img\nand --save-gif flags\nPass an RGB value\ne.g. --save-bg 255,255,255\n(Defaults to 0,0,0)\n")
+	rootCmd.PersistentFlags().IntSliceVar(&saveBgColor, "save-bg", nil, "Set background color for --save-img\nand --save-gif flags\nPass an RGBA value\ne.g. --save-bg 255,255,255,100\n(Defaults to 0,0,0,1)\n")
 	rootCmd.PersistentFlags().StringVar(&fontFile, "font", "", "Set font for --save-img and --save-gif flags\nPass file path to font .ttf file\ne.g. --font ./RobotoMono-Regular.ttf\n(Defaults to Hack-Regular for ascii and\n DejaVuSans-Oblique for braille)\n")
 	rootCmd.PersistentFlags().IntSliceVar(&fontColor, "font-color", nil, "Set font color for terminal as well as\n--save-img and --save-gif flags\nPass an RGB value\ne.g. --font-color 0,0,0\n(Defaults to 255,255,255)\n")
 	rootCmd.PersistentFlags().BoolVar(&onlySave, "only-save", false, "Don't print ascii art on terminal\nif some saving flag is passed\n")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -106,21 +106,23 @@ func checkInputAndFlags(args []string) bool {
 	}
 
 	if saveBgColor == nil {
-		saveBgColor = []int{0, 0, 0}
+		saveBgColor = []int{0, 0, 0, 100}
 	} else {
 		bgValues := len(saveBgColor)
-		if bgValues != 3 {
-			fmt.Printf("Error: --save-bg requires 3 values for RGB, got %v\n\n", bgValues)
+		if bgValues != 4 {
+			fmt.Printf("Error: --save-bg requires 4 values for RGBA, got %v\n\n", bgValues)
 			return true
 		}
 
-		if saveBgColor[0] < 0 || saveBgColor[1] < 0 || saveBgColor[2] < 0 {
+		if saveBgColor[0] < 0 || saveBgColor[1] < 0 || saveBgColor[2] < 0 || saveBgColor[3] < 0 {
 			fmt.Printf("Error: RBG values must be between 0 and 255\n\n")
+			fmt.Printf("Error: Opacity value must be between 0 and 100\n\n")
 			return true
 		}
 
-		if saveBgColor[0] > 255 || saveBgColor[1] > 255 || saveBgColor[2] > 255 {
+		if saveBgColor[0] > 255 || saveBgColor[1] > 255 || saveBgColor[2] > 255 || saveBgColor[3] > 100{
 			fmt.Printf("Error: RBG values must be between 0 and 255\n\n")
+			fmt.Printf("Error: Opacity value must be between 0 and 100\n\n")
 			return true
 		}
 	}


### PR DESCRIPTION
Hello !

First of all, i would like to congratulate you on your work ! Your tool is very funny !

I propose you to use RGBA instead of RGB for --save-bg flag.
With my modifications, i can generate images (png) with a transparent background ( r, b, g, 0 ).

Thank you !
