### PR TITLE
make conversion work with non-ascii character maps

### DIFF
--- a/image_manipulation/ascii_conversions.go
+++ b/image_manipulation/ascii_conversions.go
@@ -72,9 +72,11 @@ func ConvertToAsciiChars(imgSet [][]AsciiPixel, negative, colored, grayscale, co
 
 	} else {
 		chosenTable = map[int]string{}
+		index := 0
 
-		for index, char := range customMap {
+		for _, char := range customMap {
 			chosenTable[index] = string(char)
+			index++
 		}
 	}
 


### PR DESCRIPTION
See: <https://go.dev/blog/strings>
Using standard range iteration writes the byte offset into `index` and not the character offset, thus failing to correctly index into the output map.