### PR TITLE
Add save html

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ ascii-image-converter is a command-line tool that converts images into ascii art
 Now supports braille art!
 
 Input formats currently supported:
-
-- JPEG/JPG
-- PNG
-- BMP
-- WEBP
-- TIFF/TIF
-- GIF
+* JPEG/JPG
+* PNG
+* BMP
+* WEBP
+* TIFF/TIF
+* GIF
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/TheZoraiz/ascii-image-converter/master/example_gifs/all.gif">
@@ -25,21 +24,21 @@ Input formats currently supported:
 
 ## Table of Contents
 
-- [Installation](#installation)
-  - [Debian / Ubuntu-based](#debian-or-ubuntu-based-distros)
-  - [Homebrew](#homebrew)
-  - [AUR](#aur)
-  - [Scoop](#scoop)
-  - [Snap](#snap)
-  - [Go](#go)
-  - [Linux (binaries)](#linux)
-  - [Windows (binaries)](#windows)
-- [CLI Usage](#cli-usage)
-  - [Flags](#flags)
-- [Library Usage](#library-usage)
-- [Contributing](#contributing)
-- [Packages Used](#packages-used)
-- [License](#license)
+-  [Installation](#installation)
+	*  [Debian / Ubuntu-based](#debian-or-ubuntu-based-distros)
+	*  [Homebrew](#homebrew)
+	*  [AUR](#aur)
+	*  [Scoop](#scoop)
+	*  [Snap](#snap)
+	*  [Go](#go)
+	*  [Linux (binaries)](#linux)
+	*  [Windows (binaries)](#windows)
+-  [CLI Usage](#cli-usage)
+	*  [Flags](#flags)
+-  [Library Usage](#library-usage)
+-  [Contributing](#contributing)
+-  [Packages Used](#packages-used)
+-  [License](#license)
 
 ## Installation
 
@@ -50,15 +49,12 @@ Execute the following commands in order:
 ```
 echo 'deb [trusted=yes] https://apt.fury.io/ascii-image-converter/ /' | sudo tee /etc/apt/sources.list.d/ascii-image-converter.list
 ```
-
 ```
 sudo apt update
 ```
-
 ```
 sudo apt install -y ascii-image-converter
 ```
-
 <br>
 
 To remove the package source (which means you won't be getting any further updates), execute this command:
@@ -72,11 +68,9 @@ sudo rm -v /etc/apt/sources.list.d/ascii-image-converter.list
 ### Homebrew
 
 Installation with homebrew is available for both Linux and macOS.
-
 ```
 brew install TheZoraiz/ascii-image-converter/ascii-image-converter
 ```
-
 [Link to homebrew repository](https://github.com/TheZoraiz/homebrew-ascii-image-converter)
 
 <hr>
@@ -86,25 +80,19 @@ brew install TheZoraiz/ascii-image-converter/ascii-image-converter
 The AUR repo is maintained by [magnus-tesshu](https://aur.archlinux.org/account/magnus-tesshu)
 
 Standard way:
-
 ```
 git clone https://aur.archlinux.org/ascii-image-converter-git.git
 ```
-
 ```
 cd ascii-image-converter-git/
 ```
-
 ```
 makepkg -si
 ```
-
 AUR helper:
-
 ```
 <aur-helper> -S ascii-image-converter-git
 ```
-
 <hr>
 
 ### Scoop
@@ -119,13 +107,14 @@ scoop install ascii-image-converter
 
 ### Snap
 
+
 > **Note:** The snap will not have access to hidden files and files outside the $HOME directory. This includes write access for saving ascii art as well.
 
 ```
 sudo snap install ascii-image-converter
 ```
-
 Visit [the app's snap store listing](https://snapcraft.io/ascii-image-converter) for instructions regarding enabling snapd on your distribution.
+
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/ascii-image-converter)
 
@@ -136,7 +125,6 @@ Visit [the app's snap store listing](https://snapcraft.io/ascii-image-converter)
 ```
 go install github.com/TheZoraiz/ascii-image-converter@latest
 ```
-
 <hr>
 
 For physically installing the binaries, follow the steps with respect to your OS.
@@ -150,7 +138,6 @@ Now, open a terminal in the same directory and execute this command:
 ```
 sudo cp ascii-image-converter /usr/local/bin/
 ```
-
 Now you can use ascii-image-converter in the terminal. Execute `ascii-image-converter -h` for more details.
 
 ### Windows
@@ -158,11 +145,10 @@ Now you can use ascii-image-converter in the terminal. Execute `ascii-image-conv
 You will need to set an Environment Variable to the folder the ascii-image-converter.exe executable is placed in to be able to use it in the command prompt. Follow the instructions in case of confusion:
 
 Download the archive for your Windows architecture [here](https://github.com/TheZoraiz/ascii-image-converter/releases/latest), extract it, and open the extracted folder. Now, copy the folder path from the top of the file explorer and follow these instructions:
-
-- In Search, search for and then select: Advanced System Settings
-- Click Environment Variables. In the section User Variables find the Path environment variable and select it. Click "Edit".
-- In the Edit Environment Variable window, click "New" and then paste the path of the folder that you copied initially.
-- Click "Ok" on all open windows.
+* In Search, search for and then select: Advanced System Settings
+* Click Environment Variables. In the section User Variables find the Path environment variable and select it. Click "Edit".
+* In the Edit Environment Variable window, click "New" and then paste the path of the folder that you copied initially.
+* Click "Ok" on all open windows.
 
 Now, restart any open command prompt and execute `ascii-image-converter -h` for more details.
 
@@ -177,18 +163,16 @@ The basic usage for converting an image into ascii art is as follows. You can al
 ```
 ascii-image-converter [image paths/urls]
 ```
-
 Example:
-
 ```
 ascii-image-converter myImage.jpeg
 ```
 
 > **Note:** Piped binary input is also supported
->
 > ```
 > cat myImage.png | ascii-image-converter -
 > ```
+
 
 ### Flags
 
@@ -213,7 +197,6 @@ ascii-image-converter [image paths/urls] --color
 > **Note:** Braille pattern display heavily depends on which terminal or font you're using. In windows, try changing the font from command prompt properties if braille characters don't display
 
 Use braille characters instead of ascii. For this flag, your terminal must support braille patters (UTF-8) properly. Otherwise, you may encounter problems with colored or even uncolored braille art.
-
 ```
 ascii-image-converter [image paths/urls] -b
 # Or
@@ -229,7 +212,6 @@ ascii-image-converter [image paths/urls] --braille
 Set threshold value to compare for braille art when converting each pixel into a dot. Value must be between 0 and 255.
 
 Example:
-
 ```
 ascii-image-converter [image paths/urls] -b --threshold 170
 ```
@@ -239,7 +221,6 @@ ascii-image-converter [image paths/urls] -b --threshold 170
 Apply dithering on image to make braille art more visible. Since braille dots can only be on or off, dithering images makes them more visible in braille art.
 
 Example:
-
 ```
 ascii-image-converter [image paths/urls] -b --dither
 ```
@@ -251,7 +232,6 @@ ascii-image-converter [image paths/urls] -b --dither
 #### --color-bg
 
 If any of the coloring flags is passed, this flag will transfer its color to each character's background. instead of foreground. However, this option isn't available for `--save-img` and `--save-gif`
-
 ```
 ascii-image-converter [image paths/urls] -C --color-bg
 ```
@@ -261,19 +241,15 @@ ascii-image-converter [image paths/urls] -C --color-bg
 > **Note:** Don't immediately append another flag with -d
 
 Set the width and height for ascii art in CHARACTER lengths.
-
 ```
 ascii-image-converter [image paths/urls] -d <width>,<height>
 # Or
 ascii-image-converter [image paths/urls] --dimensions <width>,<height>
 ```
-
 Example:
-
 ```
 ascii-image-converter [image paths/urls] -d 60,30
 ```
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/TheZoraiz/ascii-image-converter/master/example_gifs/dimensions.gif">
 </p>
@@ -283,15 +259,12 @@ ascii-image-converter [image paths/urls] -d 60,30
 > **Note:** Don't immediately append another flag with -W
 
 Set width of ascii art. Height is calculated according to aspect ratio.
-
 ```
 ascii-image-converter [image paths/urls] -W <width>
 # Or
 ascii-image-converter [image paths/urls] --width <width>
 ```
-
 Example:
-
 ```
 ascii-image-converter [image paths/urls] -W 60
 ```
@@ -301,15 +274,12 @@ ascii-image-converter [image paths/urls] -W 60
 > **Note:** Don't immediately append another flag with -H
 
 Set height of ascii art. Width is calculated according to aspect ratio.
-
 ```
 ascii-image-converter [image paths/urls] -H <height>
 # Or
 ascii-image-converter [image paths/urls] --height <height>
 ```
-
 Example:
-
 ```
 ascii-image-converter [image paths/urls] -H 60
 ```
@@ -320,16 +290,14 @@ ascii-image-converter [image paths/urls] -H 60
 
 Pass a string of your own ascii characters to map against. Passed characters must start from darkest character and end with lightest. There is no limit to number of characters.
 
-Empty spaces can be passed if string is passed inside quotation marks. You can use both single or double quote for quotation marks. For repeating quotation mark inside string, append it with \ (such as \\").
+Empty spaces can be passed if string is passed inside quotation marks. You can use both single or double quote for quotation marks. For repeating quotation mark inside string, append it with \ (such as  \\").
 
 ```
 ascii-image-converter [image paths/urls] -m "<string-of-characters>"
 # Or
 ascii-image-converter [image paths/urls] --map "<string-of-characters>"
 ```
-
 Following example contains 7 depths of lighting.
-
 ```
 ascii-image-converter [image paths/urls] -m " .-=+#@"
 ```
@@ -365,7 +333,6 @@ ascii-image-converter [image paths/urls] --negative
 #### --complex OR -c
 
 Print the image with a wider array of ascii characters for more detailed lighting density. Sometimes improves accuracy.
-
 ```
 ascii-image-converter [image paths/urls] -c
 # Or
@@ -375,7 +342,6 @@ ascii-image-converter [image paths/urls] --complex
 #### --full OR -f
 
 Print ascii art that fits the terminal width while maintaining aspect ratio.
-
 ```
 ascii-image-converter [image paths/urls] -f
 # Or
@@ -393,7 +359,6 @@ ascii-image-converter [image paths/urls] -x
 ```
 
 #### --flipY OR -y
-
 Flip the ascii art vertically on the terminal.
 
 ```
@@ -401,6 +366,8 @@ ascii-image-converter [image paths/urls] --flipY
 # Or
 ascii-image-converter [image paths/urls] -y
 ```
+
+
 
 #### --save-img OR -s
 
@@ -497,7 +464,6 @@ ascii-image-converter --formats
 > **Note:** The library may throw errors during Go tests due to some unresolved bugs with the [consolesize-go](https://github.com/nathan-fiscaletti/consolesize-go) package (Only during tests, not main program execution).
 
 First, install the library with:
-
 ```
 go get -u github.com/TheZoraiz/ascii-image-converter/aic_package
 ```
@@ -542,7 +508,6 @@ func main() {
 	fmt.Printf("%v\n", asciiArt)
 }
 ```
-
 <br>
 
 > **Note:** GIF conversion is not advised as the function may run infinitely, depending on the GIF. More work needs to be done on this to make it more library-compatible.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ ascii-image-converter is a command-line tool that converts images into ascii art
 Now supports braille art!
 
 Input formats currently supported:
-* JPEG/JPG
-* PNG
-* BMP
-* WEBP
-* TIFF/TIF
-* GIF
+
+- JPEG/JPG
+- PNG
+- BMP
+- WEBP
+- TIFF/TIF
+- GIF
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/TheZoraiz/ascii-image-converter/master/example_gifs/all.gif">
@@ -24,21 +25,21 @@ Input formats currently supported:
 
 ## Table of Contents
 
--  [Installation](#installation)
-	*  [Debian / Ubuntu-based](#debian-or-ubuntu-based-distros)
-	*  [Homebrew](#homebrew)
-	*  [AUR](#aur)
-	*  [Scoop](#scoop)
-	*  [Snap](#snap)
-	*  [Go](#go)
-	*  [Linux (binaries)](#linux)
-	*  [Windows (binaries)](#windows)
--  [CLI Usage](#cli-usage)
-	*  [Flags](#flags)
--  [Library Usage](#library-usage)
--  [Contributing](#contributing)
--  [Packages Used](#packages-used)
--  [License](#license)
+- [Installation](#installation)
+  - [Debian / Ubuntu-based](#debian-or-ubuntu-based-distros)
+  - [Homebrew](#homebrew)
+  - [AUR](#aur)
+  - [Scoop](#scoop)
+  - [Snap](#snap)
+  - [Go](#go)
+  - [Linux (binaries)](#linux)
+  - [Windows (binaries)](#windows)
+- [CLI Usage](#cli-usage)
+  - [Flags](#flags)
+- [Library Usage](#library-usage)
+- [Contributing](#contributing)
+- [Packages Used](#packages-used)
+- [License](#license)
 
 ## Installation
 
@@ -49,12 +50,15 @@ Execute the following commands in order:
 ```
 echo 'deb [trusted=yes] https://apt.fury.io/ascii-image-converter/ /' | sudo tee /etc/apt/sources.list.d/ascii-image-converter.list
 ```
+
 ```
 sudo apt update
 ```
+
 ```
 sudo apt install -y ascii-image-converter
 ```
+
 <br>
 
 To remove the package source (which means you won't be getting any further updates), execute this command:
@@ -68,9 +72,11 @@ sudo rm -v /etc/apt/sources.list.d/ascii-image-converter.list
 ### Homebrew
 
 Installation with homebrew is available for both Linux and macOS.
+
 ```
 brew install TheZoraiz/ascii-image-converter/ascii-image-converter
 ```
+
 [Link to homebrew repository](https://github.com/TheZoraiz/homebrew-ascii-image-converter)
 
 <hr>
@@ -80,19 +86,25 @@ brew install TheZoraiz/ascii-image-converter/ascii-image-converter
 The AUR repo is maintained by [magnus-tesshu](https://aur.archlinux.org/account/magnus-tesshu)
 
 Standard way:
+
 ```
 git clone https://aur.archlinux.org/ascii-image-converter-git.git
 ```
+
 ```
 cd ascii-image-converter-git/
 ```
+
 ```
 makepkg -si
 ```
+
 AUR helper:
+
 ```
 <aur-helper> -S ascii-image-converter-git
 ```
+
 <hr>
 
 ### Scoop
@@ -107,14 +119,13 @@ scoop install ascii-image-converter
 
 ### Snap
 
-
 > **Note:** The snap will not have access to hidden files and files outside the $HOME directory. This includes write access for saving ascii art as well.
 
 ```
 sudo snap install ascii-image-converter
 ```
-Visit [the app's snap store listing](https://snapcraft.io/ascii-image-converter) for instructions regarding enabling snapd on your distribution.
 
+Visit [the app's snap store listing](https://snapcraft.io/ascii-image-converter) for instructions regarding enabling snapd on your distribution.
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/ascii-image-converter)
 
@@ -125,6 +136,7 @@ Visit [the app's snap store listing](https://snapcraft.io/ascii-image-converter)
 ```
 go install github.com/TheZoraiz/ascii-image-converter@latest
 ```
+
 <hr>
 
 For physically installing the binaries, follow the steps with respect to your OS.
@@ -138,6 +150,7 @@ Now, open a terminal in the same directory and execute this command:
 ```
 sudo cp ascii-image-converter /usr/local/bin/
 ```
+
 Now you can use ascii-image-converter in the terminal. Execute `ascii-image-converter -h` for more details.
 
 ### Windows
@@ -145,10 +158,11 @@ Now you can use ascii-image-converter in the terminal. Execute `ascii-image-conv
 You will need to set an Environment Variable to the folder the ascii-image-converter.exe executable is placed in to be able to use it in the command prompt. Follow the instructions in case of confusion:
 
 Download the archive for your Windows architecture [here](https://github.com/TheZoraiz/ascii-image-converter/releases/latest), extract it, and open the extracted folder. Now, copy the folder path from the top of the file explorer and follow these instructions:
-* In Search, search for and then select: Advanced System Settings
-* Click Environment Variables. In the section User Variables find the Path environment variable and select it. Click "Edit".
-* In the Edit Environment Variable window, click "New" and then paste the path of the folder that you copied initially.
-* Click "Ok" on all open windows.
+
+- In Search, search for and then select: Advanced System Settings
+- Click Environment Variables. In the section User Variables find the Path environment variable and select it. Click "Edit".
+- In the Edit Environment Variable window, click "New" and then paste the path of the folder that you copied initially.
+- Click "Ok" on all open windows.
 
 Now, restart any open command prompt and execute `ascii-image-converter -h` for more details.
 
@@ -163,16 +177,18 @@ The basic usage for converting an image into ascii art is as follows. You can al
 ```
 ascii-image-converter [image paths/urls]
 ```
+
 Example:
+
 ```
 ascii-image-converter myImage.jpeg
 ```
 
 > **Note:** Piped binary input is also supported
+>
 > ```
 > cat myImage.png | ascii-image-converter -
 > ```
-
 
 ### Flags
 
@@ -197,6 +213,7 @@ ascii-image-converter [image paths/urls] --color
 > **Note:** Braille pattern display heavily depends on which terminal or font you're using. In windows, try changing the font from command prompt properties if braille characters don't display
 
 Use braille characters instead of ascii. For this flag, your terminal must support braille patters (UTF-8) properly. Otherwise, you may encounter problems with colored or even uncolored braille art.
+
 ```
 ascii-image-converter [image paths/urls] -b
 # Or
@@ -212,6 +229,7 @@ ascii-image-converter [image paths/urls] --braille
 Set threshold value to compare for braille art when converting each pixel into a dot. Value must be between 0 and 255.
 
 Example:
+
 ```
 ascii-image-converter [image paths/urls] -b --threshold 170
 ```
@@ -221,6 +239,7 @@ ascii-image-converter [image paths/urls] -b --threshold 170
 Apply dithering on image to make braille art more visible. Since braille dots can only be on or off, dithering images makes them more visible in braille art.
 
 Example:
+
 ```
 ascii-image-converter [image paths/urls] -b --dither
 ```
@@ -232,6 +251,7 @@ ascii-image-converter [image paths/urls] -b --dither
 #### --color-bg
 
 If any of the coloring flags is passed, this flag will transfer its color to each character's background. instead of foreground. However, this option isn't available for `--save-img` and `--save-gif`
+
 ```
 ascii-image-converter [image paths/urls] -C --color-bg
 ```
@@ -241,15 +261,19 @@ ascii-image-converter [image paths/urls] -C --color-bg
 > **Note:** Don't immediately append another flag with -d
 
 Set the width and height for ascii art in CHARACTER lengths.
+
 ```
 ascii-image-converter [image paths/urls] -d <width>,<height>
 # Or
 ascii-image-converter [image paths/urls] --dimensions <width>,<height>
 ```
+
 Example:
+
 ```
 ascii-image-converter [image paths/urls] -d 60,30
 ```
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/TheZoraiz/ascii-image-converter/master/example_gifs/dimensions.gif">
 </p>
@@ -259,12 +283,15 @@ ascii-image-converter [image paths/urls] -d 60,30
 > **Note:** Don't immediately append another flag with -W
 
 Set width of ascii art. Height is calculated according to aspect ratio.
+
 ```
 ascii-image-converter [image paths/urls] -W <width>
 # Or
 ascii-image-converter [image paths/urls] --width <width>
 ```
+
 Example:
+
 ```
 ascii-image-converter [image paths/urls] -W 60
 ```
@@ -274,12 +301,15 @@ ascii-image-converter [image paths/urls] -W 60
 > **Note:** Don't immediately append another flag with -H
 
 Set height of ascii art. Width is calculated according to aspect ratio.
+
 ```
 ascii-image-converter [image paths/urls] -H <height>
 # Or
 ascii-image-converter [image paths/urls] --height <height>
 ```
+
 Example:
+
 ```
 ascii-image-converter [image paths/urls] -H 60
 ```
@@ -290,14 +320,16 @@ ascii-image-converter [image paths/urls] -H 60
 
 Pass a string of your own ascii characters to map against. Passed characters must start from darkest character and end with lightest. There is no limit to number of characters.
 
-Empty spaces can be passed if string is passed inside quotation marks. You can use both single or double quote for quotation marks. For repeating quotation mark inside string, append it with \ (such as  \\").
+Empty spaces can be passed if string is passed inside quotation marks. You can use both single or double quote for quotation marks. For repeating quotation mark inside string, append it with \ (such as \\").
 
 ```
 ascii-image-converter [image paths/urls] -m "<string-of-characters>"
 # Or
 ascii-image-converter [image paths/urls] --map "<string-of-characters>"
 ```
+
 Following example contains 7 depths of lighting.
+
 ```
 ascii-image-converter [image paths/urls] -m " .-=+#@"
 ```
@@ -333,6 +365,7 @@ ascii-image-converter [image paths/urls] --negative
 #### --complex OR -c
 
 Print the image with a wider array of ascii characters for more detailed lighting density. Sometimes improves accuracy.
+
 ```
 ascii-image-converter [image paths/urls] -c
 # Or
@@ -342,6 +375,7 @@ ascii-image-converter [image paths/urls] --complex
 #### --full OR -f
 
 Print ascii art that fits the terminal width while maintaining aspect ratio.
+
 ```
 ascii-image-converter [image paths/urls] -f
 # Or
@@ -359,6 +393,7 @@ ascii-image-converter [image paths/urls] -x
 ```
 
 #### --flipY OR -y
+
 Flip the ascii art vertically on the terminal.
 
 ```
@@ -366,8 +401,6 @@ ascii-image-converter [image paths/urls] --flipY
 # Or
 ascii-image-converter [image paths/urls] -y
 ```
-
-
 
 #### --save-img OR -s
 
@@ -402,6 +435,16 @@ Saves the passed GIF as an ascii art GIF with the name `<image-name>-ascii-art.g
 <p align="center">
   <img src="https://raw.githubusercontent.com/TheZoraiz/ascii-image-converter/master/example_gifs/save.gif">
 </p>
+
+#### --save-html
+
+Similar to --save-img but it creates a HTML file with the name `<image-name>-ascii-art.html` in the directory path passed to the flag. Can save colored text, that can be copied from open html file.
+
+Example for current directory:
+
+```
+ascii-image-converter [image paths/urls] --save-html .
+```
 
 #### --save-bg
 
@@ -454,6 +497,7 @@ ascii-image-converter --formats
 > **Note:** The library may throw errors during Go tests due to some unresolved bugs with the [consolesize-go](https://github.com/nathan-fiscaletti/consolesize-go) package (Only during tests, not main program execution).
 
 First, install the library with:
+
 ```
 go get -u github.com/TheZoraiz/ascii-image-converter/aic_package
 ```
@@ -498,6 +542,7 @@ func main() {
 	fmt.Printf("%v\n", asciiArt)
 }
 ```
+
 <br>
 
 > **Note:** GIF conversion is not advised as the function may run infinitely, depending on the GIF. More work needs to be done on this to make it more library-compatible.

--- a/aic_package/convert_image.go
+++ b/aic_package/convert_image.go
@@ -94,6 +94,22 @@ func pathIsImage(imagePath, urlImgName string, pathIsURl bool, urlImgBytes, pipe
 		}
 	}
 
+	// Save ascii art as .html file before printing it, if --save-html flag is passed
+	if saveHtmlPath != "" {
+		if err := createHtmlToSave(
+			asciiSet,
+			colored,
+			saveHtmlPath,
+			imagePath,
+			urlImgName,
+			saveBgColor,
+			onlySave,
+		); err != nil {
+
+			return "", fmt.Errorf("can't save file: %v", err)
+		}
+	}
+
 	ascii := flattenAscii(asciiSet, colored || grayscale, false)
 	result := strings.Join(ascii, "\n")
 

--- a/aic_package/convert_root.go
+++ b/aic_package/convert_root.go
@@ -54,6 +54,7 @@ func DefaultFlags() Flags {
 		SaveTxtPath:         "",
 		SaveImagePath:       "",
 		SaveGifPath:         "",
+		SaveHtmlPath:         "",
 		Negative:            false,
 		Colored:             false,
 		CharBackgroundColor: false,
@@ -90,6 +91,7 @@ func Convert(filePath string, flags Flags) (string, error) {
 	saveTxtPath = flags.SaveTxtPath
 	saveImagePath = flags.SaveImagePath
 	saveGifPath = flags.SaveGifPath
+	saveHtmlPath = flags.SaveHtmlPath
 	negative = flags.Negative
 	colored = flags.Colored
 	colorBg = flags.CharBackgroundColor

--- a/aic_package/create_ascii_html.go
+++ b/aic_package/create_ascii_html.go
@@ -1,0 +1,102 @@
+/*
+Copyright © 2021 Zoraiz Hassan <hzoraiz8@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aic_package
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	imgManip "github.com/TheZoraiz/ascii-image-converter/image_manipulation"
+)
+
+/*
+Creates and saves an HTML file containing the passed ascii art. The HTML file will contain the ascii art as spans with inline color style if [colored] is true
+*/
+func createHtmlToSave(asciiArt [][]imgManip.AsciiChar, colored bool, saveHtmlPath, imagePath, urlImgName string, saveBgColor [4]int, onlySave bool) error {
+	var builder strings.Builder
+
+	backgroundColor := fmt.Sprintf("#%02x%02x%02x", saveBgColor[0], saveBgColor[1], saveBgColor[2])
+
+	// Start the HTML file with the necessary headers and styles
+	builder.WriteString(fmt.Sprintf(`<!DOCTYPE html><html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>ASCII Art</title>
+		<style>
+			body {
+				background-color: %s;
+			}
+			span { 
+				display: inline-block; 
+				white-space: pre; 
+				font-family: monospace; 
+			}
+		</style>
+	</head><body><pre>`, backgroundColor))
+
+	for _, line := range asciiArt {
+		for _, asciiChar := range line {
+			// Extract the RGB values from the RgbValue field
+			rgb := asciiChar.RgbValue
+			// Convert the character and color into an HTML span
+			if colored {
+				builder.WriteString(fmt.Sprintf(
+					"<span style=\"color:rgb(%d,%d,%d)\">%s</span>",
+					rgb[0], rgb[1], rgb[2], asciiChar.Simple,
+				))
+			} else {
+				builder.WriteString(fmt.Sprintf(
+					"<span>%s</span>",
+					asciiChar.Simple,
+				))
+			}
+		}
+		// Add a line break after each line
+		builder.WriteString("<br>")
+	}
+
+	// End the HTML document
+	builder.WriteString(`</pre></body></html>`)
+
+
+	saveFileName, err := createSaveFileName(imagePath, urlImgName, "-ascii-art.html")
+	if err != nil {
+		return err
+	}
+
+	savePathLastChar := string(saveHtmlPath[len(saveHtmlPath)-1])
+
+	// Check if path is closed with appropriate path separator (depending on OS)
+	if savePathLastChar != string(os.PathSeparator) {
+		saveHtmlPath += string(os.PathSeparator)
+	}
+
+	// If path exists
+	if _, err := os.Stat(saveHtmlPath); !os.IsNotExist(err) {
+		err := os.WriteFile(saveHtmlPath+saveFileName, []byte(builder.String()), 0666)
+		if err != nil {
+			return err
+		} else if onlySave {
+			fmt.Println("Saved " + saveHtmlPath + saveFileName)
+		}
+		return nil
+	} else {
+		return fmt.Errorf("save path %v does not exist", saveHtmlPath)
+	}
+}

--- a/aic_package/vars.go
+++ b/aic_package/vars.go
@@ -39,6 +39,9 @@ type Flags struct {
 	// Path to save ascii art .png file
 	SaveImagePath string
 
+	// Path to save ascii art .html file
+	SaveHtmlPath string
+
 	// Path to save ascii art .gif file, if gif is passed
 	SaveGifPath string
 
@@ -111,6 +114,7 @@ var (
 	complex       bool
 	saveTxtPath   string
 	saveImagePath string
+	saveHtmlPath  string
 	saveGifPath   string
 	grayscale     bool
 	negative      bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ var (
 	height        int
 	saveTxtPath   string
 	saveImagePath string
+	saveHtmlPath  string
 	saveGifPath   string
 	negative      bool
 	formatsTrue   bool
@@ -76,6 +77,7 @@ var (
 				SaveTxtPath:         saveTxtPath,
 				SaveImagePath:       saveImagePath,
 				SaveGifPath:         saveGifPath,
+				SaveHtmlPath:        saveHtmlPath,
 				Negative:            negative,
 				Colored:             colored,
 				CharBackgroundColor: colorBg,
@@ -161,7 +163,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&saveImagePath, "save-img", "s", "", "Save ascii art as a .png file\nFormat: <image-name>-ascii-art.png\nImage will be saved in passed path\n(pass . for current directory)\n")
 	rootCmd.PersistentFlags().StringVar(&saveTxtPath, "save-txt", "", "Save ascii art as a .txt file\nFormat: <image-name>-ascii-art.txt\nFile will be saved in passed path\n(pass . for current directory)\n")
 	rootCmd.PersistentFlags().StringVar(&saveGifPath, "save-gif", "", "If input is a gif, save it as a .gif file\nFormat: <gif-name>-ascii-art.gif\nGif will be saved in passed path\n(pass . for current directory)\n")
-	rootCmd.PersistentFlags().IntSliceVar(&saveBgColor, "save-bg", nil, "Set background color for --save-img\nand --save-gif flags\nPass an RGBA value\ne.g. --save-bg 255,255,255,100\n(Defaults to 0,0,0,100)\n")
+	rootCmd.PersistentFlags().StringVar(&saveHtmlPath, "save-html", "", "Save ascii art as a .html file\nFormat: <image-name>-ascii-art.html\nFile will be saved in passed path\n(pass . for current directory)\n")
+	rootCmd.PersistentFlags().IntSliceVar(&saveBgColor, "save-bg", nil, "Set background color for --save-img\nand --save-gif \nand --save-html flags\nPass an RGBA value\ne.g. --save-bg 255,255,255,100\n(Defaults to 0,0,0,100)\n")
 	rootCmd.PersistentFlags().StringVar(&fontFile, "font", "", "Set font for --save-img and --save-gif flags\nPass file path to font .ttf file\ne.g. --font ./RobotoMono-Regular.ttf\n(Defaults to Hack-Regular for ascii and\n DejaVuSans-Oblique for braille)\n")
 	rootCmd.PersistentFlags().IntSliceVar(&fontColor, "font-color", nil, "Set font color for terminal as well as\n--save-img and --save-gif flags\nPass an RGB value\ne.g. --font-color 0,0,0\n(Defaults to 255,255,255)\n")
 	rootCmd.PersistentFlags().BoolVar(&onlySave, "only-save", false, "Don't print ascii art on terminal\nif some saving flag is passed\n")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -172,8 +172,8 @@ func checkInputAndFlags(args []string) bool {
 		return true
 	}
 
-	if (saveTxtPath == "" && saveImagePath == "" && saveGifPath == "") && onlySave {
-		fmt.Printf("Error: you need to supply one of --save-img, --save-txt or --save-gif for using --only-save\n\n")
+	if (saveTxtPath == "" && saveImagePath == "" && saveGifPath == "" && saveHtmlPath == "") && onlySave {
+		fmt.Printf("Error: you need to supply one of --save-img, --save-txt, --save-gif or --save-html for using --only-save\n\n")
 		return true
 	}
 


### PR DESCRIPTION
## What kind of change dose this PR introduce?

Adding the '--save-html' flag. 


## What is this used for?

Users can now save ascii-art as a html file. To further copy text with colored data.


## Why is it important?

Colored ascii-art can not be copied from the terminal including the colored data. Furthermore txt files can not save color. By introducing the html save useres can open the generated html file and copy the ascii-art including its text color.